### PR TITLE
Allow for custom license matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ The plugin registers a task named `rat` that you can configure in your `build.gr
 ```kotlin
 tasks.rat {
 
+    // Use the default RAT license header matchers, defaults to `true`
+    addDefaultMatchers.set(false)
+
+    // Add custom substring license header matchers
+    substringMatcher("family", "category", "pattern-1", "pattern-2")
+
+    // Declare approved license families, if used, any non-declared family won't be approved
+    approvedLicense("MIT") 
+
     // Input directory, defaults to '.'
     inputDir.set("some/path")
 

--- a/src/main/kotlin/org/nosphere/apache/rat/RatTask.kt
+++ b/src/main/kotlin/org/nosphere/apache/rat/RatTask.kt
@@ -70,6 +70,29 @@ open class RatTask private constructor(
         set(project.layout.projectDirectory)
     }
 
+    @get:Input
+    val addDefaultMatchers = project.objects.property<Boolean>().apply {
+        set(true)
+    }
+
+    @get:Nested
+    val substringMatchers = project.objects.listProperty<SubstringMatcher>().apply {
+        set(emptyList())
+    }
+
+    fun substringMatcher(licenseFamilyCategory: String, licenseFamilyName: String, vararg substrings: String) {
+        substringMatchers.add(SubstringMatcher(licenseFamilyCategory, licenseFamilyName, substrings.toList()))
+    }
+
+    @get:Input
+    val approvedLicenses = project.objects.listProperty<String>().apply {
+        set(emptyList())
+    }
+
+    fun approvedLicense(familyName: String) {
+        approvedLicenses.add(familyName)
+    }
+
     @Internal
     override fun getIncludes(): MutableSet<String> = patternSet.includes
 
@@ -123,6 +146,9 @@ open class RatTask private constructor(
     fun buildRatWorkSpec() = RatWorkSpec(
         verbose = verbose.get(),
         failOnError = failOnError.get(),
+        addDefaultMatchers = addDefaultMatchers.get(),
+        substringMatchers = substringMatchers.get(),
+        approvedLicenses = approvedLicenses.get(),
         baseDir = inputDir.asFile.get(),
         reportedFiles = inputFiles.files.filter { it.isFile },
         excludeFile = excludeFile.orNull?.asFile,

--- a/src/main/kotlin/org/nosphere/apache/rat/SubstringMatcher.kt
+++ b/src/main/kotlin/org/nosphere/apache/rat/SubstringMatcher.kt
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.nosphere.apache.rat
+
+import org.gradle.api.tasks.Input
+import java.io.Serializable
+
+
+data class SubstringMatcher(
+
+    @get:Input
+    val licenseFamilyCategory: String,
+
+    @get:Input
+    val licenseFamilyName: String,
+
+    @get:Input
+    val substrings: List<String>
+
+) : Serializable


### PR DESCRIPTION
Supporting
- disabling default matchers
- registering custom substring matchers, just like the rat ant tasks
- specifying approved license families explicitly