### PR TITLE
Use the latest gradle-build-action

### DIFF
--- a/.github/workflows/gradle-build-pr.yml
+++ b/.github/workflows/gradle-build-pr.yml
@@ -27,7 +27,7 @@ jobs:
             -   uses: actions/setup-java@v1
                 with:
                     java-version: 11
-            -   uses: eskatos/gradle-command-action@v1
+            -   uses: gradle/gradle-build-action@v2
                 env:
                     CI: true
                 with:


### PR DESCRIPTION
Testing `gradle/gradle-build-action@v2` which currently points to `v2.0-beta.2`.