### PR TITLE
Fixes #26 : Resolve Apache RAT via the buildscript context

### DIFF
--- a/src/main/kotlin/org/nosphere/apache/rat/RatTask.kt
+++ b/src/main/kotlin/org/nosphere/apache/rat/RatTask.kt
@@ -143,7 +143,7 @@ open class RatTask private constructor(
     @get:Classpath
     internal
     val ratClasspath: FileCollection = objects.fileCollection().apply {
-        from(project.run {
+        from(project.buildscript.run {
             configurations.detachedConfiguration(
                 dependencies.create("org.apache.rat:apache-rat:$ratVersion")
             )

--- a/src/test/kotlin/org/nosphere/apache/rat/BaseRatPluginTest.kt
+++ b/src/test/kotlin/org/nosphere/apache/rat/BaseRatPluginTest.kt
@@ -33,9 +33,6 @@ class BaseRatPluginTest(testMatrix: TestMatrix) : AbstractPluginTest(testMatrix)
             plugins {
                 id("org.nosphere.apache.rat-base")
             }
-            repositories {
-                mavenCentral()
-            }
             task("assertion") {
                 def hasRat = project.tasks.findByName('rat') != null
                 doLast {
@@ -55,9 +52,6 @@ class BaseRatPluginTest(testMatrix: TestMatrix) : AbstractPluginTest(testMatrix)
             """
             plugins {
                 id("org.nosphere.apache.rat-base")
-            }
-            repositories {
-                mavenCentral()
             }
             task someRat(type: org.nosphere.apache.rat.RatTask) {
                 verbose.set(true)

--- a/src/test/kotlin/org/nosphere/apache/rat/RatPluginTest.kt
+++ b/src/test/kotlin/org/nosphere/apache/rat/RatPluginTest.kt
@@ -43,9 +43,6 @@ class RatPluginTest(testMatrix: TestMatrix) : AbstractPluginTest(testMatrix) {
                 id("base")
                 id("org.nosphere.apache.rat")
             }
-            repositories {
-                mavenCentral()
-            }
             tasks.rat {
                 verbose.set(true)
                 excludes = [
@@ -88,9 +85,6 @@ class RatPluginTest(testMatrix: TestMatrix) : AbstractPluginTest(testMatrix) {
                 id("base")
                 id("org.nosphere.apache.rat")
             }
-            repositories {
-                mavenCentral()
-            }
             tasks.rat {
                 verbose.set(true)
                 excludes = [
@@ -119,9 +113,6 @@ class RatPluginTest(testMatrix: TestMatrix) : AbstractPluginTest(testMatrix) {
             plugins {
                 id("base")
                 id("org.nosphere.apache.rat")
-            }
-            repositories {
-                mavenCentral()
             }
             tasks.rat {
                 verbose.set(true)
@@ -154,9 +145,6 @@ class RatPluginTest(testMatrix: TestMatrix) : AbstractPluginTest(testMatrix) {
                 id("base")
                 id("org.nosphere.apache.rat")
             }
-            repositories {
-                mavenCentral()
-            }
             tasks.rat {
                 verbose.set(true)
                 excludes = ['build.gradle', 'settings.gradle', 'build/**', '.gradle/**', '.gradle-test-kit/**']
@@ -183,9 +171,6 @@ class RatPluginTest(testMatrix: TestMatrix) : AbstractPluginTest(testMatrix) {
                 id("base")
                 id("org.nosphere.apache.rat")
             }
-            repositories {
-                mavenCentral()
-            }
             tasks.rat {
                 verbose.set(true)
                 addDefaultMatchers.set(false)
@@ -208,9 +193,6 @@ class RatPluginTest(testMatrix: TestMatrix) : AbstractPluginTest(testMatrix) {
             plugins {
                 id("base")
                 id("org.nosphere.apache.rat")
-            }
-            repositories {
-                mavenCentral()
             }
             tasks.rat {
                 verbose.set(true)
@@ -253,9 +235,6 @@ class RatPluginTest(testMatrix: TestMatrix) : AbstractPluginTest(testMatrix) {
             plugins {
                 id("base")
                 id("org.nosphere.apache.rat")
-            }
-            repositories {
-                mavenCentral()
             }
             $someTask
             tasks.rat {


### PR DESCRIPTION
Retrieve `ConfigurationContainer` and `DependencyHandler` from the buildscript context rather than host project to ensure we resolve using the `pluginManagement` configured repositories.